### PR TITLE
Make patch event import use form-builder part

### DIFF
--- a/src/input/index.tsx
+++ b/src/input/index.tsx
@@ -6,7 +6,7 @@ import debounce from 'lodash.debounce';
 import isEqual from 'lodash.isequal';
 import classNames from 'classnames';
 import { withDocument, FormBuilderInput } from 'part:@sanity/form-builder';
-import PatchEvent, { setIfMissing } from '@sanity/form-builder/lib/PatchEvent';
+import PatchEvent, { setIfMissing } from 'part:@sanity/form-builder/patch-event';
 import { IType } from '../types/IType';
 import { IYoastPaperOptions } from '../types/IYoastPaperOptions';
 import { IField } from '../types/IField';


### PR DESCRIPTION
The path to the patchevent module should be an implementation detail - this PR changes from using a hardcoded path to using the exposed part, making sure that it works regardless of how npm chooses to hoist modules.