### PR TITLE
Update to fix the YoastSEO researchers

### DIFF
--- a/.d.ts
+++ b/.d.ts
@@ -29,7 +29,7 @@ declare module 'yoastseo' {
         constructor(paper: Paper);
         getResearch(type: 'keyphraseLength'): number;
         getResearch(type: 'metaDescriptionKeyword'): number;
-        getResearch(type: 'linkStatistics'): false | {
+        getResearch(type: 'getLinkStatistics'): false | {
             total: number;
             totalNaKeyword: number;
             keyword: {
@@ -46,7 +46,11 @@ declare module 'yoastseo' {
             otherDofollow: number;
             otherNofollow: number;
         };
-        getResearch(type: 'findKeywordInFirstParagraph'): boolean;
+        getResearch(type: 'firstParagraph'): false | {
+            foundInOneSentence: boolean;
+            foundInParagraph: boolean;
+            keyphraseOrSynonym: string;
+        };
         getResearch(type: 'getKeywordDensity'): number;
         getResearch(type: 'wordCountInText'): number;
         getResearch(type: 'keywordCount'): false | {
@@ -67,7 +71,7 @@ declare module 'yoastseo' {
             withAltKeyword: number;
             withAltNonKeyword: number;
         };
-        getResearch(type: 'pageTitleLength'): number;
+        getResearch(type: 'pageTitleWidth'): number;
         getResearch(type: 'keywordCountInUrl'): false | {
             keyphraseLength: number;
             percentWordMatches: number;
@@ -98,3 +102,11 @@ declare module 'yoastseo' {
         };
     }
 }
+declare module 'string-pixel-width' {
+    function pixelWidth(input: string,
+                        settings?: {
+                            font?: string,
+                            size?: number,
+                        }): number;
+    export default pixelWidth;
+};

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "lodash.isequal": "^4.5.0",
     "regenerator-runtime": "^0.13.7",
     "use-debounce": "^6.0.1",
-    "yoastseo": "^1.90.0"
+    "yoastseo": "^1.90.0",
+    "string-pixel-width": "^1.10.0"
   }
 }

--- a/src/input/components/SEOInput/SEOInputSeoTab.tsx
+++ b/src/input/components/SEOInput/SEOInputSeoTab.tsx
@@ -36,14 +36,14 @@ export const SEOInputSeoTab: React.FunctionComponent<Props> = ({ hidden, insight
                     <InsightResult valid={insights.keyphraseLength > 0 && insights.keywordInPageTitle && insights.keywordInPageTitle.allWordsFound}>
                         {(valid) => valid ? <>Keyphrase found in page title</> : <>Not all the words from your keyphrase "{value?.focus_keyword ?? ''}" appear in the SEO title</>}
                     </InsightResult>
-                    <InsightResult valid={insights.keyphraseLength > 0 && insights.keywordInFirstParagraph}>
+                    <InsightResult valid={insights.keyphraseLength > 0 && insights.firstParagraph && insights.firstParagraph.foundInParagraph}>
                         {(valid) => valid ? <>Keyphrase was found in your content introduction</> : <>Your keyphrase or its synonyms do not appear in the first paragraph.</>}
                     </InsightResult>
                     <InsightResult valid={insights.keyphraseLength > 0 && insights.keywordCount && insights.keywordCount.count >= idealKeywordDensity}>
                         {(valid) => valid ? <>Good keyphrase density in your content</> :  <>The focus keyphrase was found {insights.keywordCount ? insights.keywordCount.count : 0} times. That's less than the recommended minimum of {idealKeywordDensity} times for a text of this length.</>}
                     </InsightResult>
-                    <InsightResult valid={insights.linkStatistics && insights.linkStatistics.internalTotal > 0}>Internal links</InsightResult>
-                    <InsightResult valid={insights.linkStatistics && insights.linkStatistics.externalTotal > 0}>Outbound links</InsightResult>
+                    <InsightResult valid={insights.getLinkStatistics && insights.getLinkStatistics.internalTotal > 0}>Internal links</InsightResult>
+                    <InsightResult valid={insights.getLinkStatistics && insights.getLinkStatistics.externalTotal > 0}>Outbound links</InsightResult>
                     {(insights.altTagCount && (insights.altTagCount.noAlt + insights.altTagCount.withAlt > 4)) && (
                         <InsightResult valid={altTagCountPercentage >= .3 && altTagCountPercentage <= .7}>
                             {(valid) => valid
@@ -56,10 +56,10 @@ export const SEOInputSeoTab: React.FunctionComponent<Props> = ({ hidden, insight
                             }
                         </InsightResult>
                     )}
-                    {insights.pageTitleLength === 0 && (
+                    {insights.pageTitleWidth === 0 && (
                         <InsightResult valid={false}>Be sure to include an SEO title on your page</InsightResult>
                     )}
-                    {insights.pageTitleLength > 600 && (
+                    {insights.pageTitleWidth > 600 && (
                         <InsightResult valid={false}>Your SEO title should not be longer than 600px for optimal visibility in search engines.</InsightResult>
                     )}
                     {(insights.keywordCountInUrl && insights.keywordCountInUrl.percentWordMatches < 100) && (

--- a/src/input/utils/getYoastInsightsForContent.ts
+++ b/src/input/utils/getYoastInsightsForContent.ts
@@ -1,3 +1,5 @@
+import pixelWidth from 'string-pixel-width';
+
 type TOptions = {
     keyword: string;
     url: string;
@@ -13,7 +15,8 @@ export const getYoastInsightsForContent = (YoastSEO: typeof import('yoastseo'), 
         keyword: options.keyword,
         url: options.url,
         permalink: options.permalink,
-        title: options.permalink,
+        title: options.title,
+        ...(options.title && {titleWidth: pixelWidth(options.title, { font: 'arial', size: 20 })}),
         synonyms: options.synonyms.join(','),
         description: options.description,
         locale: options.langCulture.replace('-', '_'),
@@ -22,14 +25,14 @@ export const getYoastInsightsForContent = (YoastSEO: typeof import('yoastseo'), 
     return {
         keyphraseLength: researcher.getResearch('keyphraseLength'),
         metaDescriptionKeyword: researcher.getResearch('metaDescriptionKeyword'),
-        linkStatistics: researcher.getResearch('linkStatistics'),
-        keywordInFirstParagraph: researcher.getResearch('findKeywordInFirstParagraph'),
+        getLinkStatistics: researcher.getResearch('getLinkStatistics'),
+        firstParagraph: researcher.getResearch('firstParagraph'),
         keywordDensity: researcher.getResearch('getKeywordDensity'),
         wordCountInText: researcher.getResearch('wordCountInText'),
         keywordCount:  researcher.getResearch('keywordCount'),
         keywordInPageTitle:  researcher.getResearch('findKeywordInPageTitle'),
         altTagCount: researcher.getResearch('altTagCount'),
-        pageTitleLength: researcher.getResearch('pageTitleLength'),
+        pageTitleWidth: researcher.getResearch('pageTitleWidth'),
         keywordCountInUrl: researcher.getResearch('keywordCountInUrl'),
         countSentencesFromText: researcher.getResearch('countSentencesFromText'),
         passiveVoice: researcher.getResearch('passiveVoice'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -4176,6 +4176,11 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
+lodash.deburr@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
+  integrity sha1-3bG7s+8HRYwBd7oH3hRCLLAz/5s=
+
 lodash.isequal@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
@@ -6298,6 +6303,13 @@ string-hash@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/string-hash/-/string-hash-1.1.3.tgz#e8aafc0ac1855b4666929ed7dd1275df5d6c811b"
   integrity sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs=
+
+string-pixel-width@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/string-pixel-width/-/string-pixel-width-1.10.0.tgz#aff215aaa7a65627f937d70fcc88d83ae1bc5657"
+  integrity sha512-cOMpkH+CpxWAnrPsWUvPWhZxh25CzUukweT+6WF+Kwx6+G2ksg8flvELZusLyWiZzfFCjj1+QRRGwcPWZlwVYA==
+  dependencies:
+    lodash.deburr "^4.1.0"
 
 string-width@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
linkStatistics, findKeywordInFirstParagraph, and pageTitleLength
needed to be updated to getLinkStatistics, firstParagraph, and
pageTitleWidth respectively. To support pageTitleWidth counting the
pixel width as opposed to the character count, there is a new depedency
on [string-pixel-width](https://www.npmjs.com/package/string-pixel-width).