### PR TITLE
Enhanced SEO Content Selection and Aggregation

### DIFF
--- a/src/utils/prepareRemoteData.ts
+++ b/src/utils/prepareRemoteData.ts
@@ -32,7 +32,14 @@ export async function prepareRemoteData(
   // find the title, description and content
   const title = doc.title || doc.querySelector('h1')?.textContent || doc.querySelector('h2')?.textContent || ''
   const description = doc.querySelector<HTMLMetaElement>('meta[name="description"]')?.content || ''
-  const content = doc.querySelector(contentSelector)?.innerHTML || ''
+  const nodeList = doc.querySelectorAll(`[data-content='seo']`)
+  const createElement = doc.createElement('main')
+  await Promise.all(
+    Array.from(nodeList).map((n) => createElement.appendChild(n))
+  );
+  const contentHtml = doc.querySelector(contentSelector)?.innerHTML || ''
+  const mainElement = createElement?.innerHTML
+  const content = nodeList?.length ? mainElement : contentHtml
 
   return {
     locale: langCulture,


### PR DESCRIPTION
Enhanced SEO Content Selection and Aggregation

### The Problem
The plugin starts by attempting to select the `content` of an HTML element with a given selector (`contentSelector`) using `querySelector`. However, it was limited to selecting content from a single HTML element. Sometimes it grabs some unnecessary elements from the root that we might not want to detect, such as author image alternative text, and a related post article image alt text in a blog post. This becomes a common problem if a developer has structured their content in a way where not all the HTML elements they want analyzed for SEO are not located in the Rich text editor for the content body of a blog article, for example. 

### The Enhanced Solution:

1. Ability to select Multiple Elements: Provide a way for the developer can target multiple elements on a page to be analyzed by the SEO plugin. These elements are identified by the `[data-content="seo"]` attribute.

2. Aggregate Content: Instead of selecting content from a single element, we want to aggregate the content from all the elements with the `[data-content="seo"]` attribute into a single container (`mainElement`).

3. Fallback Mechanism: If there are no elements with the `[data-content="seo"]` attribute on the page, the plugin will have a fallback mechanism to retrieve content using the original `contentSelector`.

By making these changes, we are adapting the code to handle more diverse scenarios where there might be multiple content instances with the `[data-content="seo"]` attribute on the page. This enhanced solution ensures we can effectively aggregate and handle this content, providing a more robust and flexible solution to your problem.

In summary, the problem we are addressing is the need to target multiple HTML elements that need to be analyzed for SEO by the plugin and ensure that our code can gracefully handle scenarios with or without these elements.

Example of selecting multiple contents of a blog post article:
```
<div>
 <h2 className=’blog-subtitle’ data-content="seo">
          		{post?.excerpt}
 	 </h2>
<!--Start of the element we want to avoid -->
<ArticleSideBarSticky
            author={post?.author}
            publishedAt={post?.publishedAt}
            categories={post?.categories}
          />
<!--End of the element we want to avoid -->
          <Richtext postBody={post?.body} data-content="seo" />
 </div>
```

